### PR TITLE
Use the default provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_required_version"></a> [required\_version](#requirement\_required\_version) | >= 1.0.1 |
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Try a query like `select * from lb_logs limit 100;`
 module "lb-access-logs-enabled" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer"
 
+  providers = {
+    # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
+    # Need to pass the provider to the S3 bucket module
+    aws.bucket-replication = aws
+  }
   vpc_all                             = "${local.vpc_name}-${local.environment}"
   #existing_bucket_name               = "my-bucket-name"
   application_name                    = local.application_name

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  alias  = "bucket-replication"
-  region = "eu-west-2"
-  assume_role {
-    role_arn = "arn:aws:iam::${var.account_number}:role/MemberInfrastructureAccess"
-  }
-}
+# provider "aws" {
+# 	alias = "bucket-replication"
+# }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -58,7 +58,11 @@ data "aws_subnet" "public_subnets_c" {
 
 module "lb_access_logs_enabled" {
   source = "../.."
-
+  providers = {
+    # Here we use the default provider for the S3 bucket module, buck replication is disabled but we still
+    # Need to pass the provider to the S3 bucket module
+    aws.bucket-replication = aws
+  }
   vpc_all                    = "${local.vpc_name}-${local.environment}"
   application_name           = local.application_name
   public_subnets             = [data.aws_subnet.public_subnets_a.id, data.aws_subnet.public_subnets_b.id, data.aws_subnet.public_subnets_c.id]

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,10 @@ terraform {
     aws = {
       version = "~> 4.0"
       source  = "hashicorp/aws"
+      configuration_aliases = [
+         aws.bucket-replication,
+      ]
     }
-  }
   required_version = ">= 1.0.1"
+  }
 }


### PR DESCRIPTION
This causes issues when running a local plan as the local user does not have access to the current provider given.  By passing in the default provider to the S3 bucket module we solve this.  This provider is not needed as the S3 bucket does not use replication, but because of the way that providers work it's not possible to just to have a default.