### PR TITLE
DSOS-1627: allow multiple load balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "aws_security_group" "lb" {
 
 
 resource "aws_athena_database" "lb-access-logs" {
-  name   = "loadbalancer_access_logs"
+  name   = "${var.application_name}-lb-access-logs"
   bucket = var.existing_bucket_name != "" ? var.existing_bucket_name : module.s3-bucket[0].bucket.id
   encryption_configuration {
     encryption_option = "SSE_S3"

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "aws_security_group" "lb" {
 
 
 resource "aws_athena_database" "lb-access-logs" {
-  name   = "${var.application_name}-lb-access-logs"
+  name   = replace("${var.application_name}-lb-access-logs", "-", "_") # dashes not allowed in name
   bucket = var.existing_bucket_name != "" ? var.existing_bucket_name : module.s3-bucket[0].bucket.id
   encryption_configuration {
     encryption_option = "SSE_S3"

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ resource "aws_lb" "loadbalancer" {
   tags = merge(
     var.tags,
     {
-      Name = "lb-${var.application_name}"
+      Name = "${var.application_name}-lb"
     },
   )
 }
@@ -173,6 +173,13 @@ resource "aws_security_group" "lb" {
       security_groups = lookup(egress.value, "security_groups", null)
     }
   }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.application_name}-lb-security-group"
+    },
+  )
 }
 
 
@@ -211,4 +218,11 @@ resource "aws_athena_workgroup" "lb-access-logs" {
       }
     }
   }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.application_name}-lb-access-logs"
+    },
+  )
 }

--- a/test/load_balancer_test.go
+++ b/test/load_balancer_test.go
@@ -19,7 +19,7 @@ func TestLBCreation(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	athenaDbName := terraform.Output(t, terraformOptions, "athena_db_name")
-	assert.Equal(t, "loadbalancer_access_logs", athenaDbName)
+	assert.Regexp(t, regexp.MustCompile(`*lb_access_logs`), athenaDbName)
 	securityGroupArn := terraform.Output(t, terraformOptions, "security_group_arn")
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:ec2:eu-west-2:[0-9]{12}:security-group\/sg-*`), securityGroupArn)
 	loadbalancerArn := terraform.Output(t, terraformOptions, "load_balancer_arn")

--- a/test/load_balancer_test.go
+++ b/test/load_balancer_test.go
@@ -19,7 +19,7 @@ func TestLBCreation(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	athenaDbName := terraform.Output(t, terraformOptions, "athena_db_name")
-	assert.Regexp(t, regexp.MustCompile(`*lb_access_logs`), athenaDbName)
+	assert.Regexp(t, regexp.MustCompile(`lb_access_logs`), athenaDbName)
 	securityGroupArn := terraform.Output(t, terraformOptions, "security_group_arn")
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:ec2:eu-west-2:[0-9]{12}:security-group\/sg-*`), securityGroupArn)
 	loadbalancerArn := terraform.Output(t, terraformOptions, "load_balancer_arn")


### PR DESCRIPTION
Some tweaks to the module to ensure multiple load balancers can be created, e.g. one public and one internal.
Changes:
- create athena database with unique name (otherwise 2nd load balancer will fail as "loadbalancer_access_logs" is already created)
- aligned the loadbalancer Name tag with the name of the resource
- added missing tags to security group and athena workgroup resources
