### PR TITLE
documentation fix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      
+
 permissions: read-all
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0 # v1.0.0
+      uses: terraform-docs/gh-actions@18dc76d9b2e3c746cf6f8e073c7fa7df16dcf620 # v1.0.0
       with:
         working-dir: .
         output-file: README.md

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions: 
+  pull-requests: write
+  contents: write
 
 jobs:
   docs:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 | [aws_iam_policy.lb_glue_crawler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.lb_glue_crawler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.lb_glue_crawler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.lb_glue_servicec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lb_glue_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lb.loadbalancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_security_group.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |


### PR DESCRIPTION
The current workflow for the documentation is broken due to set-output being depicted i have found that there is currently a fix for this in https://github.com/terraform-docs/gh-actions/issues/97 and that is to tie the render to a particular hash of the repo. This PR implements this fix