### PR TITLE
Logic to handle `access_logs=false`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -301,11 +301,13 @@ data "aws_iam_policy_document" "lb_glue_crawler_assume" {
 }
 
 resource "aws_iam_policy" "lb_glue_crawler" {
+  count  = var.access_logs ? 1 : 0
   name   = "LbGlueCrawler"
-  policy = data.aws_iam_policy_document.lb_glue_crawler.json
+  policy = data.aws_iam_policy_document.lb_glue_crawler[count.index].json
 }
 
 data "aws_iam_policy_document" "lb_glue_crawler" {
+  count = var.access_logs ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -318,8 +320,9 @@ data "aws_iam_policy_document" "lb_glue_crawler" {
 
 # Glue Crawler Policy
 resource "aws_iam_role_policy_attachment" "lb_glue_crawler" {
+  count      = var.access_logs ? 1 : 0
   role       = aws_iam_role.lb_glue_crawler.name
-  policy_arn = aws_iam_policy.lb_glue_crawler.arn
+  policy_arn = aws_iam_policy.lb_glue_crawler[count.index].arn
 }
 
 resource "aws_iam_role_policy_attachment" "lb_glue_service" {
@@ -330,6 +333,7 @@ resource "aws_iam_role_policy_attachment" "lb_glue_service" {
 # Glue Crawler
 resource "aws_glue_crawler" "ssm_resource_sync" {
   #checkov:skip=CKV_AWS_195
+  count         = var.access_logs ? 1 : 0
   database_name = aws_athena_database.lb-access-logs[0].name
   name          = "lb_resource_sync"
   role          = aws_iam_role.lb_glue_crawler.arn


### PR DESCRIPTION
If `access_logs` is assigned false, module users experience the following errors. 
Extra conditionals have been added to the PR to address this.

```
│ Error: Invalid index
│ 
│   on .terraform/modules/baseline.lb/main.tf line 315, in data "aws_iam_policy_document" "lb_glue_crawler":
│  315:     resources = [var.existing_bucket_name != "" ? "arn:aws:s3:::${var.existing_bucket_name}/${var.application_name}/AWSLogs/${var.account_number}/*" : "${module.s3-bucket[0].bucket.arn}/${var.application_name}/AWSLogs/${var.account_number}/*"]
│     ├────────────────
│     │ module.s3-bucket is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.

│ Error: Invalid index
│ 
│   on .terraform/modules/baseline.lb/main.tf line 333, in resource "aws_glue_crawler" "ssm_resource_sync":
│  333:   database_name = aws_athena_database.lb-access-logs[0].name
│     ├────────────────
│     │ aws_athena_database.lb-access-logs is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.

```