### PR TITLE
Bug fix: glue s3 path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -349,6 +349,6 @@ resource "aws_glue_crawler" "ssm_resource_sync" {
   schedule      = var.log_schedule
 
   s3_target {
-    path = var.existing_bucket_name != "" ? "s3://${var.existing_bucket_name}" : "s3://${module.s3-bucket[0].bucket.id}"
+    path = var.existing_bucket_name != "" ? "s3://${var.existing_bucket_name}/${var.application_name}/AWSLogs/${var.account_number}/elasticloadbalancing/" : "s3://${module.s3-bucket[0].bucket.id}/${var.application_name}/AWSLogs/${var.account_number}/elasticloadbalancing/"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -349,6 +349,6 @@ resource "aws_glue_crawler" "ssm_resource_sync" {
   schedule      = var.log_schedule
 
   s3_target {
-    path = "s3://${var.existing_bucket_name}"
+    path = var.existing_bucket_name != "" ? "s3://${var.existing_bucket_name}" : "s3://${module.s3-bucket[0].bucket.id}"
   }
 }


### PR DESCRIPTION
The current version is broken as var.existing_bucket_name is not always populated.
Corrected the path. Tested as much as I can in nomis-test but the proof of the pudding will be CSR, but I need it merged into main to test that. 