### PR TITLE
added dns name and zone id outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,5 +219,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 | <a name="output_lb_target_groups"></a> [lb\_target\_groups](#output\_lb\_target\_groups) | n/a |
 | <a name="output_load_balancer"></a> [load\_balancer](#output\_load\_balancer) | n/a |
 | <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | n/a |
+| <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | n/a |
+| <a name="output_load_balancer_zone_id"></a> [load\_balancer\_zone\_id](#output\_load\_balancer\_zone\_id) | n/a |
 | <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,12 @@ output "load_balancer_arn" {
 output "lb_target_groups" {
   value = aws_lb_target_group.this
 }
+
+output "load_balancer_dns_name" {
+  value = aws_lb.loadbalancer.dns_name
+}
+
+output "load_balancer_zone_id" {
+  value = aws_lb.loadbalancer.zone_id
+
+}


### PR DESCRIPTION
Adds extra functionality so you can reference the load balancer Zone ID and DNS name when using the module.