### PR TITLE
updated regex for alb logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -436,7 +436,7 @@ resource "aws_glue_catalog_table" "application_lb_logs" {
     }
     columns {
       name = "target_status_code"
-      type = "int"
+      type = "string"
     }
     columns {
       name = "received_bytes"
@@ -475,7 +475,7 @@ resource "aws_glue_catalog_table" "application_lb_logs" {
       type = "string"
     }
     columns {
-      name = "trace_header"
+      name = "trace_id"
       type = "string"
     }
     columns {
@@ -488,7 +488,7 @@ resource "aws_glue_catalog_table" "application_lb_logs" {
     }
     columns {
       name = "matched_rule_priority"
-      type = "int"
+      type = "string"
     }
     columns {
       name = "request_creation_time"
@@ -523,7 +523,7 @@ resource "aws_glue_catalog_table" "application_lb_logs" {
       type = "string"
     }
     columns {
-      name = "trace_id"
+      name = "conn_trace_id"
       type = "string"
     }
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

[7107](https://github.com/ministryofjustice/modernisation-platform/issues/7107)

## How does this PR fix the problem?

Regular expression has been updated to match the names used in AWS's official documentation and have been assigned the correct data types. 
