### PR TITLE
TM-1215 fix s3 bucket location

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v8.2.1 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 474f27a3f9bf542a8826c76fb049cc84b5cf136f |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_vpc" "shared" {
 
 module "s3-bucket" {
   count  = var.existing_bucket_name == "" && var.access_logs ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1" #version 8.2.1 
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" #v8.2.1
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_vpc" "shared" {
 
 module "s3-bucket" {
   count  = var.existing_bucket_name == "" && var.access_logs ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1" #version 8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1" #version 8.2.1 
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,7 @@ data "aws_vpc" "shared" {
 
 module "s3-bucket" {
   count  = var.existing_bucket_name == "" && var.access_logs ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=568694e50e03630d99cb569eafa06a0b879a1239" # v7.1.0
-
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v8.2.1" #version 8.2.1
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }


### PR DESCRIPTION
The s3 bucket listed in the main.tf pointed to an older version so it now points to the correct one of 8.2.1.

Please approve so we can move this into production. At present it is causing errors.